### PR TITLE
[Feat] #7 소셜 로그인 기본세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/lokoko/domain/user/entity/User.java
+++ b/src/main/java/com/lokoko/domain/user/entity/User.java
@@ -1,0 +1,55 @@
+package com.lokoko.domain.user.entity;
+
+import com.lokoko.domain.user.entity.enums.PersonalColor;
+import com.lokoko.domain.user.entity.enums.Role;
+import com.lokoko.domain.user.entity.enums.SkinTone;
+import com.lokoko.domain.user.entity.enums.SkinType;
+import com.lokoko.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String lineId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.USER;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private PersonalColor personalColor;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private SkinTone skinTone;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private SkinType skinType;
+
+    /*
+     * TODO: 추후 scope 확장 시, 필드추가
+     */
+}

--- a/src/main/java/com/lokoko/domain/user/entity/enums/PersonalColor.java
+++ b/src/main/java/com/lokoko/domain/user/entity/enums/PersonalColor.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.user.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PersonalColor {
+    SPRING_WARM("봄 웜"),
+    SUMMER_COOL("여름 쿨"),
+    AUTUMN_WARM("가을 웜"),
+    AUTUMN_COOL("가을 쿨"),
+    WINTER_COOL("겨울 쿨"),
+    NOT_SPECIFIED("모름");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/user/entity/enums/Role.java
+++ b/src/main/java/com/lokoko/domain/user/entity/enums/Role.java
@@ -1,0 +1,13 @@
+package com.lokoko.domain.user.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("일반 유저"),
+    ADMIN("관리자");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/user/entity/enums/SkinTone.java
+++ b/src/main/java/com/lokoko/domain/user/entity/enums/SkinTone.java
@@ -1,0 +1,16 @@
+package com.lokoko.domain.user.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SkinTone {
+    BELOW_17("17호 미만"),
+    FROM_17_TO_19("17-19호"),
+    FROM_19_TO_21("19-21호"),
+    FROM_21_TO_23("21-23호"),
+    ABOVE_23("23호 초과");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/user/entity/enums/SkinType.java
+++ b/src/main/java/com/lokoko/domain/user/entity/enums/SkinType.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.user.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SkinType {
+    NORMAL("건성"),
+    OILY("지성"),
+    COMBINATION("복합성"),
+    SENSITIVE("아토피성"),
+    AGING("안정성"),
+    OTHER("기타");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/global/auth/annotation/CurrentUserId.java
+++ b/src/main/java/com/lokoko/global/auth/annotation/CurrentUserId.java
@@ -1,0 +1,11 @@
+package com.lokoko.global.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/com/lokoko/global/auth/annotation/CurrentUserResolver.java
+++ b/src/main/java/com/lokoko/global/auth/annotation/CurrentUserResolver.java
@@ -1,0 +1,10 @@
+package com.lokoko.global.auth.annotation;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CurrentUserResolver {
+    /*
+     * TODO: JWT_USER_ID_CLAIM로 사용자 ID를 추출하는 로직 구현 예정
+     */
+}

--- a/src/main/java/com/lokoko/global/auth/authentication/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/lokoko/global/auth/authentication/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.lokoko.global.auth.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lokoko.global.common.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final static String LOG_FORMAT = "ExceptionClass: {}, Message: {}";
+    private final static String CONTENT_TYPE = "application/json";
+    private final static String CHAR_ENCODING = "UTF-8";
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        log.error(LOG_FORMAT, accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage(),
+                accessDeniedException);
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(CONTENT_TYPE);
+        response.setCharacterEncoding(CHAR_ENCODING);
+
+        ApiResponse<Void> body = ApiResponse.error(HttpStatus.FORBIDDEN, accessDeniedException.getMessage());
+        String json = new ObjectMapper().writeValueAsString(body);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/lokoko/global/auth/authentication/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,51 @@
+package com.lokoko.global.auth.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lokoko.global.auth.exception.ErrorMessage;
+import com.lokoko.global.common.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String LOG_FORMAT = "ExceptionClass: {}, Message: {}";
+    private static final String JWT_ERROR_ATTR = "jwtError";
+    private static final String CONTENT_TYPE = "application/json";
+    private static final String CHAR_ENCODING = "UTF-8";
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        ErrorMessage jwtError = (ErrorMessage) request.getAttribute(JWT_ERROR_ATTR);
+
+        String errorMessage = (jwtError != null)
+                ? jwtError.getMessage()
+                : authException.getMessage();
+
+        String exceptionClass = (jwtError != null)
+                ? jwtError.getClass().getSimpleName()
+                : authException.getClass().getSimpleName();
+
+        log.error(LOG_FORMAT, exceptionClass, errorMessage, (jwtError != null ? jwtError : authException));
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(CONTENT_TYPE);
+        response.setCharacterEncoding(CHAR_ENCODING);
+
+        ApiResponse<Void> body = ApiResponse.error(
+                HttpStatus.UNAUTHORIZED,
+                errorMessage
+        );
+        String json = new ObjectMapper().writeValueAsString(body);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/entity/enums/OauthLoginStatus.java
+++ b/src/main/java/com/lokoko/global/auth/entity/enums/OauthLoginStatus.java
@@ -1,0 +1,13 @@
+package com.lokoko.global.auth.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthLoginStatus {
+    LOGIN("소셜 로그인"),
+    REGISTER("최초 소셜 회원가입");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/global/auth/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/global/auth/exception/ErrorMessage.java
@@ -1,0 +1,12 @@
+package com.lokoko.global.auth.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    OAUTH_ERROR("OAuth 인증에 실패했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/global/auth/exception/OauthException.java
+++ b/src/main/java/com/lokoko/global/auth/exception/OauthException.java
@@ -1,0 +1,10 @@
+package com.lokoko.global.auth.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class OauthException extends BaseException {
+    public OauthException() {
+        super(HttpStatus.UNAUTHORIZED, ErrorMessage.OAUTH_ERROR.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/dto/JwtTokenDto.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/dto/JwtTokenDto.java
@@ -1,0 +1,21 @@
+package com.lokoko.global.auth.jwt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokenDto(
+        String accessToken,
+        String refreshToken
+) {
+    public static JwtTokenDto of(String accessToken, String refreshToken) {
+        return JwtTokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken).build();
+    }
+
+    public static JwtTokenDto of(String accessToken) {
+        return JwtTokenDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/dto/RefreshTokenDto.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/dto/RefreshTokenDto.java
@@ -1,0 +1,8 @@
+package com.lokoko.global.auth.jwt.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RefreshTokenDto(
+        @NotNull String refreshToken
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/exception/ErrorMessage.java
@@ -1,0 +1,21 @@
+package com.lokoko.global.auth.jwt.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    USER_NOT_FOUND_EMAIL("해당 이메일의 유저를 찾을 수 없습니다"),
+    JWT_TOKEN_FORBIDDEN("권한이 없습니다."),
+    JWT_TOKEN_NOT_FOUND("토큰을 찾을 수 없습니다"),
+    JWT_TOKEN_EXPIRED("만료된 토큰입니다."),
+    JWT_TOKEN_INVALID("유효하지 않은 토큰 입니다."),
+    JWT_TOKEN_UN_VALID("유효하지 않은 토큰 입니다."),
+    JWT_TOKEN_NOT_EXIST("헤더에 인증 토큰이 존재하지 않습니다"),
+
+    COOKIE_NOT_FOUND("헤더에 RefreshToken이 없습니다."),
+    REDIS_NOT_FOUND("Redis 에서 찾을 수 없습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.lokoko.global.auth.jwt.filter;
+
+import static com.lokoko.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_EXPIRED;
+import static com.lokoko.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_INVALID;
+import static com.lokoko.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_NOT_FOUND;
+
+import com.lokoko.global.auth.jwt.principal.JwtUserDetails;
+import com.lokoko.global.auth.jwt.utils.JwtExtractor;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final static String JWT_ERROR = "jwtError";
+    private final JwtExtractor jwtExtractor;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        Optional<String> token = jwtExtractor.extractJwtToken(request);
+
+        if (token.isEmpty()) {
+            request.setAttribute(JWT_ERROR, JWT_TOKEN_NOT_FOUND);
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+        String accessToken = token.get();
+
+        if (!jwtExtractor.validateJwtToken(accessToken)) {
+            request.setAttribute(JWT_ERROR, JWT_TOKEN_INVALID);
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        if (jwtExtractor.isExpired(accessToken)) {
+            request.setAttribute(JWT_ERROR, JWT_TOKEN_EXPIRED);
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+        saveAuthentcation(accessToken);
+        filterChain.doFilter(request, response);
+    }
+
+    private void saveAuthentcation(String token) {
+        Long id = jwtExtractor.getId(token);
+        String email = jwtExtractor.getEmail(token);
+        String role = jwtExtractor.getRole(token);
+
+        UserDetails userDetails = JwtUserDetails.of(id, email, role);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
+                userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/principal/JwtUserDetails.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/principal/JwtUserDetails.java
@@ -1,0 +1,23 @@
+package com.lokoko.global.auth.jwt.principal;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+@Getter
+public class JwtUserDetails extends User {
+
+    private final Long id;
+
+    public JwtUserDetails(Long id, String email, List<GrantedAuthority> authorities) {
+        super(email, "", authorities);
+        this.id = id;
+    }
+
+    public static JwtUserDetails of(Long id, String email, String role) {
+        return new JwtUserDetails(id, email, Collections.singletonList(new SimpleGrantedAuthority(role)));
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/utils/JwtExtractor.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/utils/JwtExtractor.java
@@ -1,0 +1,84 @@
+package com.lokoko.global.auth.jwt.utils;
+
+import static com.lokoko.global.auth.jwt.utils.JwtProvider.ACCESS_TOKEN_SUBJECT;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtExtractor {
+    private static final String BEARER = "Bearer ";
+    private static final String ID_CLAIM = "id";
+    private static final String ROLE_CLAIM = "role";
+    private static final String EMAIL_CLAIM = "email";
+    private final Key key;
+
+    public JwtExtractor(@Value("${lokoko.jwt.key}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public Optional<String> extractJwtToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_SUBJECT))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Long getId(String token) {
+        return getIdFromToken(token, ID_CLAIM);
+    }
+
+    public String getEmail(String token) {
+        return getClaimFromToken(token, EMAIL_CLAIM);
+    }
+
+    public String getRole(String token) {
+        return getClaimFromToken(token, ROLE_CLAIM);
+    }
+
+    public Boolean isExpired(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().before(new Date());
+    }
+
+    private String getClaimFromToken(String token, String claimName) {
+        Claims claims = parseClaims(token);
+        return claims.get(claimName, String.class);
+    }
+
+    private Long getIdFromToken(String token, String claimName) {
+        Claims claims = parseClaims(token);
+        return claims.get(claimName, Long.class);
+    }
+
+    private Claims parseClaims(String token) {
+        JwtParser parser = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build();
+        Claims claims = parser.parseClaimsJws(token).getBody();
+        return claims;
+    }
+
+    public boolean validateJwtToken(String token) {
+        try {
+            JwtParser parser = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build();
+            parser.parseClaimsJws(token).getBody();
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/utils/JwtProvider.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/utils/JwtProvider.java
@@ -1,0 +1,61 @@
+package com.lokoko.global.auth.jwt.utils;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+    public static final String ACCESS_TOKEN_SUBJECT = "Authorization";
+    public static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String ID_CLAIM = "id";
+    private static final String ROLE_CLAIM = "role";
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    private final Key key;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtProvider(
+            @Value("${lokoko.jwt.key}") String secretKey,
+            @Value("${lokoko.jwt.access.expiration}") long accessTokenExpiration,
+            @Value("${lokoko.jwt.refresh.expiration}") long refreshTokenExpiration
+    ) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    public String generateAccessToken(Long userId, String role) {
+        JwtBuilder builder = Jwts.builder()
+                .setSubject(ACCESS_TOKEN_SUBJECT)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .claim(ID_CLAIM, userId)
+                .claim(ROLE_CLAIM, ROLE_PREFIX + role);
+
+        return builder
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId, String role) {
+        JwtBuilder builder = Jwts.builder()
+                .setSubject(REFRESH_TOKEN_SUBJECT)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .claim(ID_CLAIM, userId)
+                .claim(ROLE_CLAIM, ROLE_PREFIX + role);
+
+        return builder
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}
+

--- a/src/main/java/com/lokoko/global/auth/service/AuthService.java
+++ b/src/main/java/com/lokoko/global/auth/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.lokoko.global.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    /*
+     * TODO: 소셜 로그인 및 JWT 토큰 발급 로직 구현 예정
+     */
+}

--- a/src/main/java/com/lokoko/global/common/response/ApiResponse.java
+++ b/src/main/java/com/lokoko/global/common/response/ApiResponse.java
@@ -8,14 +8,7 @@ public record ApiResponse<T>(
         String message,
         T data
 ) {
-    /**
-     * Creates a successful API response with the specified HTTP status, message, and data payload.
-     *
-     * @param httpStatus the HTTP status to include in the response
-     * @param message the message describing the result
-     * @param data the data payload to include in the response
-     * @return an ApiResponse instance representing a successful operation
-     */
+
     public static <T> ApiResponse<T> success(
             HttpStatus httpStatus,
             String message,
@@ -29,13 +22,6 @@ public record ApiResponse<T>(
         );
     }
 
-    /**
-     * Creates a successful API response with the specified HTTP status and message, without a data payload.
-     *
-     * @param httpStatus the HTTP status to include in the response
-     * @param message the message describing the result
-     * @return an ApiResponse instance representing a successful operation with no data
-     */
     public static ApiResponse<Void> success(
             HttpStatus httpStatus,
             String message
@@ -43,14 +29,6 @@ public record ApiResponse<T>(
         return success(httpStatus, message, null);
     }
 
-    /**
-     * Creates an error ApiResponse with the specified HTTP status, message, and data payload.
-     *
-     * @param httpStatus the HTTP status to set in the response
-     * @param message the error message to include
-     * @param data the data payload to include in the response
-     * @return an ApiResponse representing an error with the provided details
-     */
     public static <T> ApiResponse<T> error(
             HttpStatus httpStatus,
             String message,
@@ -64,13 +42,6 @@ public record ApiResponse<T>(
         );
     }
 
-    /**
-     * Creates an error ApiResponse with the specified HTTP status and message, without a data payload.
-     *
-     * @param httpStatus the HTTP status to set in the response
-     * @param message the error message to include in the response
-     * @return an ApiResponse instance representing an error, with no data
-     */
     public static ApiResponse<Void> error(
             HttpStatus httpStatus,
             String message

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -1,0 +1,27 @@
+package com.lokoko.global.config;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PermitUrlConfig {
+
+    public String[] getPublicUrl() {
+        return new String[]{
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+        };
+    }
+
+    public String[] getUserUrl() {
+        return new String[]{
+
+        };
+    }
+
+    public String[] getAdminUrl() {
+        return new String[]{
+                "/api/admin/**"
+        };
+    }
+
+}

--- a/src/main/java/com/lokoko/global/config/SecurityConfig.java
+++ b/src/main/java/com/lokoko/global/config/SecurityConfig.java
@@ -1,31 +1,79 @@
 package com.lokoko.global.config;
 
+import static com.lokoko.domain.user.entity.enums.Role.ADMIN;
+import static com.lokoko.domain.user.entity.enums.Role.USER;
+
+import com.lokoko.global.auth.authentication.CustomAccessDeniedHandler;
+import com.lokoko.global.auth.authentication.CustomAuthenticationEntryPoint;
+import com.lokoko.global.auth.jwt.filter.JwtAuthenticationFilter;
+import com.lokoko.global.auth.jwt.utils.JwtExtractor;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final PermitUrlConfig permitUrlConfig;
+    private final CustomAuthenticationEntryPoint authEntryPoint;
+    private final CustomAccessDeniedHandler deniedHandler;
+    private final JwtExtractor jwtExtractor;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/*").permitAll()
-                .anyRequest().permitAll());
+                .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
+                .requestMatchers(permitUrlConfig.getUserUrl()).hasAnyRole(USER.name(), ADMIN.name())
+                .requestMatchers(permitUrlConfig.getAdminUrl()).hasRole(ADMIN.name())
+                .anyRequest().authenticated());
+
+        http.exceptionHandling(e -> e
+                .authenticationEntryPoint(authEntryPoint)
+                .accessDeniedHandler(deniedHandler));
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtExtractor), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(
+                Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "RefreshToken"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
+        urlBasedCorsConfigurationSource.registerCorsConfiguration("/**", configuration);
+        return urlBasedCorsConfigurationSource;
+    }
 }
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,3 +11,17 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+line:
+  channel-id: ${LINE_CHANNEL_ID}
+  channel-secret: ${LINE_CHANNEL_SECRET}
+  scope: ${LINE_SCOPE}
+
+lokoko:
+  jwt:
+    key: ${JWT_KEY}
+    access:
+      expiration: ${ACCESS_EXP}
+      header: ${ACCESS_HEAD}
+    refresh:
+      expiration: ${REFRESH_EXP}
+      header: ${REFRESH_HEAD}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,4 +11,17 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+line:
+  channel-id: ${LINE_CHANNEL_ID}
+  channel-secret: ${LINE_CHANNEL_SECRET}
+  scope: ${LINE_SCOPE}
 
+lokoko:
+  jwt:
+    key: ${JWT_KEY}
+    access:
+      expiration: ${ACCESS_EXP}
+      header: ${ACCESS_HEAD}
+    refresh:
+      expiration: ${REFRESH_EXP}
+      header: ${REFRESH_HEAD}


### PR DESCRIPTION
## Related issue 🛠

- closed #6 

## 작업 내용 💻

- [x] 유저 엔티티 생성 (24일 ERD 확정 후 변경 가능)
- [x] LINE Oauth 콘솔 기본 세팅
- [x] LINE Oauth 관련 환경변수 추가
- [x] JWT 관련 내용 수정
- [x] 소셜 회원가입 / 로그인 분기로 처리
- [x] 최초 회원가입시 입력받을 뷰티 프로필 API 구현 (피부톤, 퍼스널 컬러, 피부타입)

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 소셜 로그인 세부 로직은 변경 사항이 많아서 해당 PR에서 따로 안했고, 작업 내용은 내일 대면회의때 공유 예정입니다

