### PR TITLE
[Feat] #10 라인 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     //Spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -39,6 +40,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Netty DNS Resolver
+    runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64")
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/lokoko/domain/user/entity/User.java
+++ b/src/main/java/com/lokoko/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import com.lokoko.domain.user.entity.enums.PersonalColor;
 import com.lokoko.domain.user.entity.enums.Role;
 import com.lokoko.domain.user.entity.enums.SkinTone;
 import com.lokoko.domain.user.entity.enums.SkinType;
+import com.lokoko.domain.user.entity.enums.UserStatus;
 import com.lokoko.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,8 +35,11 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String lineId;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
+
+    @Column
+    private LocalDateTime lastLoginAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -52,7 +57,24 @@ public class User extends BaseEntity {
     @Column
     private SkinType skinType;
 
+    @Column(name = "status", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private UserStatus status = UserStatus.ACTIVE;
+
     /*
      * TODO: 추후 scope 확장 시, 필드추가
      */
+
+    public static User createLineUser(String lineUserId) {
+        return User.builder()
+                .lineId(lineUserId)
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .lastLoginAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/lokoko/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/com/lokoko/domain/user/entity/enums/UserStatus.java
@@ -1,0 +1,16 @@
+package com.lokoko.domain.user.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserStatus {
+
+    ACTIVE("활성화"),
+    INACTIVE("비활성화"),
+    SUSPENDED("정지"),
+    WITHDRAWN("탈퇴");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/lokoko/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.user.repository;
+
+import com.lokoko.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByLineId(String lineId);
+}

--- a/src/main/java/com/lokoko/global/auth/controller/AuthController.java
+++ b/src/main/java/com/lokoko/global/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.lokoko.global.auth.controller;
+
+import static com.lokoko.global.auth.controller.enums.ResponseMessage.LOGIN_SUCCESS;
+import static com.lokoko.global.auth.controller.enums.ResponseMessage.URL_GET_SUCCESS;
+
+import com.lokoko.global.auth.jwt.dto.JwtTokenDto;
+import com.lokoko.global.auth.line.dto.LineLoginResponse;
+import com.lokoko.global.auth.line.dto.LoginUrlResponse;
+import com.lokoko.global.auth.service.AuthService;
+import com.lokoko.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @GetMapping("/line/login")
+    public ApiResponse<LineLoginResponse> lineLogin(@RequestParam("code") String code) {
+        JwtTokenDto tokens = authService.loginWithLine(code);
+
+        return ApiResponse.success(HttpStatus.OK, LOGIN_SUCCESS.getMessage(), new LineLoginResponse(tokens));
+    }
+
+    @GetMapping("/url")
+    public ApiResponse<LoginUrlResponse> getLoginUrl() {
+        String url = authService.generateLineLoginUrl();
+
+        return ApiResponse.success(HttpStatus.OK, URL_GET_SUCCESS.getMessage(), new LoginUrlResponse(url));
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/global/auth/controller/enums/ResponseMessage.java
@@ -1,0 +1,13 @@
+package com.lokoko.global.auth.controller.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    LOGIN_SUCCESS("회원가입/로그인 성공에 성공했습니다."),
+    URL_GET_SUCCESS("리다이렉트 URL 조회에 성공했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/global/auth/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/global/auth/exception/ErrorMessage.java
@@ -2,11 +2,22 @@ package com.lokoko.global.auth.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
-    OAUTH_ERROR("OAuth 인증에 실패했습니다.");
+    OAUTH_ERROR("OAuth 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED.value()),
+
+    // LINE 관련
+    LINE_TOKEN_REQUEST_FAILED("LINE 토큰 요청에 실패했습니다.", HttpStatus.BAD_GATEWAY.value()),
+    LINE_PROFILE_FETCH_FAILED("LINE 프로필 조회에 실패했습니다.", HttpStatus.BAD_GATEWAY.value()),
+
+    // state 관련
+    STATE_PARAMETER_REQUIRED("State 매개변수가 필요합니다.", HttpStatus.BAD_REQUEST.value()),
+    STATE_PARAMETER_INVALID("유효하지 않거나 만료된 State 매개변수입니다.", HttpStatus.BAD_REQUEST.value()),
+    STATE_PARAMETER_EXPIRED("State 매개변수가 만료되었습니다.", HttpStatus.BAD_REQUEST.value());
 
     private final String message;
+    private final int httpStatus;
 }

--- a/src/main/java/com/lokoko/global/auth/exception/OauthException.java
+++ b/src/main/java/com/lokoko/global/auth/exception/OauthException.java
@@ -4,7 +4,12 @@ import com.lokoko.global.common.exception.BaseException;
 import org.springframework.http.HttpStatus;
 
 public class OauthException extends BaseException {
+
     public OauthException() {
-        super(HttpStatus.UNAUTHORIZED, ErrorMessage.OAUTH_ERROR.getMessage());
+        this(ErrorMessage.OAUTH_ERROR);
+    }
+
+    public OauthException(ErrorMessage errorMessage) {
+        super(HttpStatus.UNAUTHORIZED, errorMessage.getMessage());
     }
 }

--- a/src/main/java/com/lokoko/global/auth/exception/StateValidationException.java
+++ b/src/main/java/com/lokoko/global/auth/exception/StateValidationException.java
@@ -1,0 +1,22 @@
+package com.lokoko.global.auth.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class StateValidationException extends BaseException {
+    public StateValidationException(ErrorMessage errorMessage) {
+        super(HttpStatus.BAD_REQUEST, errorMessage.getMessage());
+    }
+
+    public static StateValidationException required() {
+        return new StateValidationException(ErrorMessage.STATE_PARAMETER_REQUIRED);
+    }
+
+    public static StateValidationException invalid() {
+        return new StateValidationException(ErrorMessage.STATE_PARAMETER_INVALID);
+    }
+
+    public static StateValidationException expired() {
+        return new StateValidationException(ErrorMessage.STATE_PARAMETER_EXPIRED);
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/jwt/dto/JwtTokenDto.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/dto/JwtTokenDto.java
@@ -1,21 +1,19 @@
 package com.lokoko.global.auth.jwt.dto;
 
+import com.lokoko.global.auth.entity.enums.OauthLoginStatus;
 import lombok.Builder;
 
 @Builder
 public record JwtTokenDto(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        OauthLoginStatus loginStatus
 ) {
-    public static JwtTokenDto of(String accessToken, String refreshToken) {
-        return JwtTokenDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken).build();
-    }
-
-    public static JwtTokenDto of(String accessToken) {
-        return JwtTokenDto.builder()
-                .accessToken(accessToken)
-                .build();
+    public static JwtTokenDto of(
+            String accessToken,
+            String refreshToken,
+            OauthLoginStatus loginStatus
+    ) {
+        return new JwtTokenDto(accessToken, refreshToken, loginStatus);
     }
 }

--- a/src/main/java/com/lokoko/global/auth/jwt/exception/JwtErrorMessage.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/exception/JwtErrorMessage.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorMessage {
+public enum JwtErrorMessage {
     USER_NOT_FOUND_EMAIL("해당 이메일의 유저를 찾을 수 없습니다"),
     JWT_TOKEN_FORBIDDEN("권한이 없습니다."),
     JWT_TOKEN_NOT_FOUND("토큰을 찾을 수 없습니다"),

--- a/src/main/java/com/lokoko/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package com.lokoko.global.auth.jwt.filter;
 
-import static com.lokoko.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_EXPIRED;
-import static com.lokoko.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_INVALID;
-import static com.lokoko.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_NOT_FOUND;
+import static com.lokoko.global.auth.jwt.exception.JwtErrorMessage.JWT_TOKEN_EXPIRED;
+import static com.lokoko.global.auth.jwt.exception.JwtErrorMessage.JWT_TOKEN_INVALID;
+import static com.lokoko.global.auth.jwt.exception.JwtErrorMessage.JWT_TOKEN_NOT_FOUND;
 
 import com.lokoko.global.auth.jwt.principal.JwtUserDetails;
 import com.lokoko.global.auth.jwt.utils.JwtExtractor;
@@ -21,6 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String NO_CHECK_URL = "";
     private final static String JWT_ERROR = "jwtError";
     private final JwtExtractor jwtExtractor;
 

--- a/src/main/java/com/lokoko/global/auth/jwt/utils/JwtProvider.java
+++ b/src/main/java/com/lokoko/global/auth/jwt/utils/JwtProvider.java
@@ -1,6 +1,5 @@
 package com.lokoko.global.auth.jwt.utils;
 
-import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -33,27 +32,24 @@ public class JwtProvider {
     }
 
     public String generateAccessToken(Long userId, String role) {
-        JwtBuilder builder = Jwts.builder()
-                .setSubject(AUTHORIZATION_HEADER)
+        return Jwts.builder()
+                .setSubject(userId.toString())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .setExpiration(new Date(System.currentTimeMillis()
+                        + accessTokenExpiration))
                 .claim(ID_CLAIM, userId)
-                .claim(ROLE_CLAIM, ROLE_PREFIX + role);
-
-        return builder
+                .claim(ROLE_CLAIM, ROLE_PREFIX + role)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public String generateRefreshToken(Long userId, String role) {
-        JwtBuilder builder = Jwts.builder()
-                .setSubject(REFRESH_TOKEN_HEADER)
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .setSubject(userId.toString())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .setExpiration(new Date(System.currentTimeMillis()
+                        + refreshTokenExpiration))
                 .claim(ID_CLAIM, userId)
-                .claim(ROLE_CLAIM, ROLE_PREFIX + role);
-
-        return builder
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/com/lokoko/global/auth/line/LineConstants.java
+++ b/src/main/java/com/lokoko/global/auth/line/LineConstants.java
@@ -1,0 +1,24 @@
+package com.lokoko.global.auth.line;
+
+public class LineConstants {
+    // Base URL
+    public static final String AUTHORIZE_PATH = "https://access.line.me/oauth2/v2.1/authorize";
+    public static final String TOKEN_PATH = "/oauth2/v2.1/token";
+    public static final String PROFILE_PATH = "/v2/profile";
+    // OAuth
+    public static final String PARAM_RESPONSE_TYPE = "?response_type=code";
+    public static final String PARAM_GRANT_TYPE = "grant_type";
+    public static final String PARAM_CODE = "code";
+    public static final String REDIRECT_URI = "redirect_uri";
+    public static final String CLIENT_ID = "client_id";
+    public static final String PARAM_REDIRECT_URI = "&redirect_uri=";
+    public static final String PARAM_CLIENT_ID = "&client_id=";
+    public static final String PARAM_CLIENT_SECRET = "client_secret";
+    public static final String PARAM_SCOPE = "&scope=profile%20openid";
+    public static final String PARAM_STATE = "&state=";
+    public static final String RESPONSE_TYPE_CODE = "code";
+    public static final String GRANT_TYPE_AUTH_CODE = "authorization_code";
+
+    private LineConstants() {
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/line/LineOAuthClient.java
+++ b/src/main/java/com/lokoko/global/auth/line/LineOAuthClient.java
@@ -1,0 +1,37 @@
+package com.lokoko.global.auth.line;
+
+import com.lokoko.global.auth.line.dto.LineProfileResponse;
+import com.lokoko.global.auth.line.dto.LineTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class LineOAuthClient {
+    private final WebClient lineWebClient;
+    private final LineProperties props;
+
+    public LineTokenResponse issueToken(String code) {
+        return lineWebClient.post()
+                .uri(LineConstants.TOKEN_PATH)
+                .body(BodyInserters.fromFormData(LineConstants.PARAM_GRANT_TYPE, LineConstants.GRANT_TYPE_AUTH_CODE)
+                        .with(LineConstants.PARAM_CODE, code)
+                        .with(LineConstants.REDIRECT_URI, props.getRedirectUri())
+                        .with(LineConstants.CLIENT_ID, props.getClientId())
+                        .with(LineConstants.PARAM_CLIENT_SECRET, props.getClientSecret()))
+                .retrieve()
+                .bodyToMono(LineTokenResponse.class)
+                .block();
+    }
+
+    public LineProfileResponse fetchProfile(String accessToken) {
+        return lineWebClient.get()
+                .uri(LineConstants.PROFILE_PATH)
+                .headers(h -> h.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(LineProfileResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/line/LineProperties.java
+++ b/src/main/java/com/lokoko/global/auth/line/LineProperties.java
@@ -1,0 +1,18 @@
+package com.lokoko.global.auth.line;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "line")
+@Getter
+@Setter
+public class LineProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String baseUrl;
+    private String scope;
+}

--- a/src/main/java/com/lokoko/global/auth/line/dto/LineLoginResponse.java
+++ b/src/main/java/com/lokoko/global/auth/line/dto/LineLoginResponse.java
@@ -1,0 +1,8 @@
+package com.lokoko.global.auth.line.dto;
+
+import com.lokoko.global.auth.jwt.dto.JwtTokenDto;
+
+public record LineLoginResponse(
+        JwtTokenDto tokens
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/line/dto/LineProfileResponse.java
+++ b/src/main/java/com/lokoko/global/auth/line/dto/LineProfileResponse.java
@@ -1,0 +1,9 @@
+package com.lokoko.global.auth.line.dto;
+
+public record LineProfileResponse(
+        String userId,
+        String displayName,
+        String pictureUrl,
+        String statusMessage
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/line/dto/LineTokenResponse.java
+++ b/src/main/java/com/lokoko/global/auth/line/dto/LineTokenResponse.java
@@ -1,0 +1,9 @@
+package com.lokoko.global.auth.line.dto;
+
+public record LineTokenResponse(
+        String access_token,
+        String refresh_token,
+        Long expires_in,
+        String id_token
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/line/dto/LoginUrlResponse.java
+++ b/src/main/java/com/lokoko/global/auth/line/dto/LoginUrlResponse.java
@@ -1,0 +1,6 @@
+package com.lokoko.global.auth.line.dto;
+
+public record LoginUrlResponse(
+        String authorizationUrl
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/service/AuthService.java
+++ b/src/main/java/com/lokoko/global/auth/service/AuthService.java
@@ -1,12 +1,85 @@
 package com.lokoko.global.auth.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import static com.lokoko.global.auth.line.LineConstants.AUTHORIZE_PATH;
+import static com.lokoko.global.auth.line.LineConstants.PARAM_CLIENT_ID;
+import static com.lokoko.global.auth.line.LineConstants.PARAM_REDIRECT_URI;
+import static com.lokoko.global.auth.line.LineConstants.PARAM_RESPONSE_TYPE;
+import static com.lokoko.global.auth.line.LineConstants.PARAM_SCOPE;
+import static com.lokoko.global.auth.line.LineConstants.PARAM_STATE;
 
+import com.lokoko.domain.user.entity.User;
+import com.lokoko.domain.user.repository.UserRepository;
+import com.lokoko.global.auth.entity.enums.OauthLoginStatus;
+import com.lokoko.global.auth.exception.ErrorMessage;
+import com.lokoko.global.auth.exception.OauthException;
+import com.lokoko.global.auth.exception.StateValidationException;
+import com.lokoko.global.auth.jwt.dto.JwtTokenDto;
+import com.lokoko.global.auth.jwt.utils.JwtProvider;
+import com.lokoko.global.auth.line.LineOAuthClient;
+import com.lokoko.global.auth.line.LineProperties;
+import com.lokoko.global.auth.line.dto.LineProfileResponse;
+import com.lokoko.global.auth.line.dto.LineTokenResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    /*
-     * TODO: 소셜 로그인 및 JWT 토큰 발급 로직 구현 예정
-     */
+    private final StateService stateService;
+    private final LineOAuthClient oAuthClient;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final LineProperties props;
+
+    @Transactional
+    public JwtTokenDto loginWithLine(String code) {
+        try {
+            LineTokenResponse tokenResp = oAuthClient.issueToken(code);
+
+            LineProfileResponse profile = oAuthClient.fetchProfile(tokenResp.access_token());
+            String lineUserId = profile.userId();
+
+            Optional<User> userOpt = userRepository.findByLineId(lineUserId);
+            User user;
+            OauthLoginStatus loginStatus;
+
+            if (userOpt.isPresent()) {
+                user = userOpt.get();
+                user.updateLastLoginAt();
+                userRepository.save(user);
+                loginStatus = OauthLoginStatus.LOGIN;
+            } else {
+                user = User.createLineUser(lineUserId);
+                user = userRepository.save(user);
+                loginStatus = OauthLoginStatus.REGISTER;
+            }
+
+            String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getRole().name());
+            String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+            return JwtTokenDto.of(accessToken, refreshToken, loginStatus);
+
+        } catch (StateValidationException ex) {
+            log.warn("State 검증 실패: {}", ex.getMessage());
+            throw ex;
+        } catch (Exception ex) {
+            log.error("LINE OAuth 로그인 처리 중 오류 발생", ex);
+            throw new OauthException(ErrorMessage.OAUTH_ERROR);
+        }
+    }
+
+    public String generateLineLoginUrl() {
+        String state = stateService.generateState();
+
+        return AUTHORIZE_PATH +
+                PARAM_RESPONSE_TYPE +
+                PARAM_CLIENT_ID + props.getClientId() +
+                PARAM_REDIRECT_URI + props.getRedirectUri() +
+                PARAM_STATE + state +
+                PARAM_SCOPE;
+    }
 }

--- a/src/main/java/com/lokoko/global/auth/service/StateService.java
+++ b/src/main/java/com/lokoko/global/auth/service/StateService.java
@@ -1,0 +1,42 @@
+package com.lokoko.global.auth.service;
+
+import com.lokoko.global.auth.exception.StateValidationException;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StateService {
+    private static final long STATE_EXPIRATION_MINUTES = 10;
+    private final ConcurrentHashMap<String, Long> stateStore = new ConcurrentHashMap<>();
+
+    public String generateState() {
+        String state = UUID.randomUUID().toString();
+        long expirationTime = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(STATE_EXPIRATION_MINUTES);
+        stateStore.put(state, expirationTime);
+        cleanExpiredStates();
+        return state;
+    }
+
+    public void verify(String state) {
+
+        if (state == null || state.isBlank()) {
+            throw StateValidationException.required();
+        }
+
+        Long expirationTime = stateStore.remove(state);
+        if (expirationTime == null) {
+            throw StateValidationException.invalid();
+        }
+
+        if (System.currentTimeMillis() > expirationTime) {
+            throw StateValidationException.expired();
+        }
+    }
+
+    private void cleanExpiredStates() {
+        long currentTime = System.currentTimeMillis();
+        stateStore.entrySet().removeIf(entry -> entry.getValue() < currentTime);
+    }
+}

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -9,6 +9,7 @@ public class PermitUrlConfig {
         return new String[]{
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
+                "/auth/**",
         };
     }
 

--- a/src/main/java/com/lokoko/global/config/SecurityConfig.java
+++ b/src/main/java/com/lokoko/global/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setExposedHeaders(Arrays.asList("Authorization", "RefreshToken"));
-        configuration.setAllowCredentials(true);
+        configuration.setAllowCredentials(false);
 
         UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
         urlBasedCorsConfigurationSource.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/lokoko/global/config/WebClientConfig.java
+++ b/src/main/java/com/lokoko/global/config/WebClientConfig.java
@@ -1,0 +1,23 @@
+package com.lokoko.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${line.base-url}")
+    private String lineBaseUrl;
+
+    @Bean
+    public WebClient lineWebClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl(lineBaseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,8 +12,10 @@ spring:
     hibernate:
       ddl-auto: update
 line:
-  channel-id: ${LINE_CHANNEL_ID}
-  channel-secret: ${LINE_CHANNEL_SECRET}
+  client-id: ${LINE_CHANNEL_ID}
+  client-secret: ${LINE_CHANNEL_SECRET}
+  redirect-uri: ${LINE_CALLBACK_URL}
+  base-url: ${LINE_BASE_URL}
   scope: ${LINE_SCOPE}
 
 lokoko:


### PR DESCRIPTION
## Related issue 🛠

- closed #9 

## 작업 내용 💻

- [x] `AuthService` 세부 로직 구현
- [x] `AuthController` 추가
- [x] JWT 필터 세부 로직 개선
- [x] 유저 엔티티 초기 구현 (scope 추가시 수정 예정)
- [x] 유저 레포 추가
- [x] `LineOAuthClient` 로직으로 리다이렉트 기능까지 구현 

## 스크린샷 📷

x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 아마도 작업 볼륨상 redis 까지 도입해서 리프레시 토큰을 발행하는건 다음 PR에서 할 예정입니다
- 어제 전체회의에서 나왔듯이, 최초 로그인시 별도의 API로 넘겨주는 것은 (세부 정보 입력) MVP에서 제외가 돼서, 확장성 생각해서 분리만 해놨고
해당 API는 빼고 구현했어요
